### PR TITLE
Added JSDoc parser support for inputs and outputs

### DIFF
--- a/helpers/demestifyAPI.js
+++ b/helpers/demestifyAPI.js
@@ -74,12 +74,37 @@ function getCommentedParams(index, file) {
   }
   try {
     let item = [...params].reverse().join('').split('\n');
+    let inputs = {};
+    let outputs = {};
     item.forEach(function (param) {
       let temp = param.split('-');
       if (temp.length == 2) {
         temp[0] = temp[0].trim();
-        temp[0] = temp[0].substring(temp[0].lastIndexOf(' '));
-        data[temp[0].trim()] = String(temp[1].trim());
+        let dataInsideBrackets;
+        if (temp[0].includes('[') && temp[0].includes(']')) {
+          dataInsideBrackets = temp[0].match(/\[([^)]+)\]/)[1];
+        }
+        if (dataInsideBrackets) {
+          if (dataInsideBrackets == 'inputs') {
+            temp[0] = temp[0].substring(temp[0].lastIndexOf(' '));
+            temp[0] = temp[0].trim();
+            temp[1] = temp[1].trim();
+            inputs[temp[0]] = String(temp[1]);
+          } else if (dataInsideBrackets == 'outputs') {
+            temp[0] = temp[0].substring(temp[0].lastIndexOf(' '));
+            temp[0] = temp[0].trim();
+            temp[1] = temp[1].trim();
+            outputs[temp[0]] = String(temp[1]);
+          } else {
+            temp[0] = temp[0].substring(temp[0].lastIndexOf(' '));
+            data[temp[0].trim()] = String(temp[1].trim());
+          }
+          data.inputs = inputs;
+          data.outputs = outputs;
+        } else {
+          temp[0] = temp[0].substring(temp[0].lastIndexOf(' '));
+          data[temp[0].trim()] = String(temp[1].trim());
+        }
       }
     });
     return data;

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -8,13 +8,28 @@ let testApiDefinition = `
  * @constructor
  * @param {string} title - The title of the book.
  * @param {string} author - The author of the book.
+ * @param {string} [inputs] name- The name of the user.
+ * @param {string} [inputs] password- The password of the user.
+ * @param {string} [outputs] userid- The id of the new user created.
+ * @param {string} [outputs] error- Error message if any.
  */
 `;
 describe('🔄 JSDOC Parser Test', function () {
   it('should parse JSDOC like syntax', function () {
     assert.deepEqual(
       getCommentedParams(testApiDefinition.length - 1, testApiDefinition),
-      { title: 'The title of the book.', author: 'The author of the book.' }
+      {
+        title: 'The title of the book.',
+        author: 'The author of the book.',
+        inputs: {
+          name: 'The name of the user.',
+          password: 'The password of the user.',
+        },
+        outputs: {
+          userid: 'The id of the new user created.',
+          error: 'Error message if any.',
+        },
+      }
     );
   });
 });


### PR DESCRIPTION
## Proposed changes
Added JSDoc parser support to handle inputs and outputs. The params object now contain additional objects for inputs and outputs. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/Pika1998/express-autodocs/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)



<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, test steps, etc... -->